### PR TITLE
Add slug-based routing for posts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ vendor/
 *.md
 
 #Ignore .log files
-/tmp/*.log
+tmp/*.log
+!tmp/.gitkeep

--- a/app/Controllers/HomeController.php
+++ b/app/Controllers/HomeController.php
@@ -7,8 +7,6 @@ class HomeController extends BaseController
 
     public function index()
     {
-//        session()->set('name', 'Mykhailo');
-//        session()->delete('name');
         $posts = db()->findAll('posts');
         return view('home', ['title' => 'Home', 'posts' => $posts]);
     }

--- a/app/Controllers/PostController.php
+++ b/app/Controllers/PostController.php
@@ -7,6 +7,16 @@ use App\Models\Post;
 class PostController extends BaseController
 {
 
+    public function show()
+    {
+        $slug = router()->route_params['slug'] ?? '';
+        $post = db()->query('SELECT * FROM posts WHERE slug = ?', [$slug])->getOne();
+        if (!$post) {
+            abort();
+        }
+
+        return view('posts/show', ['title' => $post['title'], 'post' => $post]);
+    }
     public function edit()
     {
         $id = request()->get('id');

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -9,7 +9,7 @@ class Post extends Model
 
     public string $table = 'posts';
 
-    public array $fillable = ['title', 'content'];
+    public array $fillable = ['title', 'content', 'slug'];
     public array $rules = [
         'title' => [
             'required' => true,
@@ -17,10 +17,15 @@ class Post extends Model
         'content' => [
             'required' => true,
         ],
+        'slug' => [
+            'required' => true,
+            'unique' => 'posts,slug',
+        ]
     ];
     public array $labels = [
         'title' => 'Post title',
         'content' => 'Post content',
+        'slug' => 'Slug',
     ];
 
 }

--- a/app/Views/home.php
+++ b/app/Views/home.php
@@ -5,7 +5,7 @@
 
     <?php if (!empty($posts)): ?>
         <?php foreach ($posts as $post): ?>
-            <h3><a href="#"><?= $post['title']; ?></a> | <a href="<?= base_url('/posts/edit?id=' . $post['id']) ?>">EDIT</a> | <a href="<?= base_url('/posts/delete?id=' . $post['id']) ?>">DELETE</a></h3>
+            <h3><a href="posts/<?= $post['slug']; ?>"><?= $post['title']; ?></a> | <a href="<?= base_url('/posts/edit?id=' . $post['id']) ?>">EDIT</a> | <a href="<?= base_url('/posts/delete?id=' . $post['id']) ?>">DELETE</a></h3>
         <?php endforeach; ?>
     <?php endif; ?>
 

--- a/app/Views/posts/create.php
+++ b/app/Views/posts/create.php
@@ -15,6 +15,12 @@
                 </div>
 
                 <div class="mb-3">
+                    <label for="slug" class="form-label">Slug</label>
+                    <input type="text" name="slug" id="slug" class="form-control <?= get_validation_class('slug', $errors ?? []) ?>" placeholder="Slug" value="<?= old('slug') ?>">
+                    <?= get_errors('slug', $errors ?? []) ?>
+                </div>
+
+                <div class="mb-3">
                     <label for="content" class="form-label">Content</label>
                     <textarea name="content" id="content" class="form-control <?= get_validation_class('content', $errors ?? []) ?>" rows="3"><?= old('content') ?></textarea>
                     <?= get_errors('content', $errors ?? []) ?>

--- a/app/Views/posts/show.php
+++ b/app/Views/posts/show.php
@@ -1,0 +1,6 @@
+<div class="card text-center m-3" style="width: 12rem;">
+    <div class="card-body">
+        <h5 class="card-title"><?= $post['title']; ?></h5>
+        <p class="card-text"><?= $post['content']; ?></p>
+    </div>
+</div>

--- a/config/routes.php
+++ b/config/routes.php
@@ -18,3 +18,5 @@ $app->router->post('/posts/update', [\App\Controllers\PostController::class, 'up
 
 $app->router->get('/posts/delete', [\App\Controllers\PostController::class, 'delete']);
 $app->router->post('/posts/update', [\App\Controllers\PostController::class, 'update']);
+
+$app->router->get('/posts/(?P<slug>[a-z0-9-]+)', [\App\Controllers\PostController::class, 'show']);

--- a/core/Database.php
+++ b/core/Database.php
@@ -23,7 +23,7 @@ class Database
         return $this;
     }
 
-    public function query(string $query, array $params = [])
+    public function query(string $query, array $params = []): static
     {
         try {
             $this->stmt = $this->conn->prepare($query);
@@ -46,19 +46,24 @@ class Database
         return $this->stmt->fetchAll();
     }
 
+    public function getOne(): mixed
+    {
+        return $this->stmt->fetch();
+    }
+
     public function findAll($tbl): array|false
     {
         $this->query("SELECT * FROM {$tbl} ORDER BY id ASC");
         return $this->stmt->fetchAll();
     }
 
-    public function findOne($tbl, $id)
+    public function findOne($tbl, $id): mixed
     {
         $this->query("SELECT * FROM {$tbl} WHERE id = ? LIMIT 1", [$id]);
         return $this->stmt->fetch();
     }
 
-    public function findOrFail($tbl, $id)
+    public function findOrFail($tbl, $id): mixed
     {
         $result = $this->findOne($tbl, $id);
         if (!$result) {
@@ -76,6 +81,11 @@ class Database
     public function getRowCount(): int
     {
         return $this->stmt->rowCount();
+    }
+
+    public function getColumn(): mixed
+    {
+        return $this->stmt->fetchColumn();
     }
 
     public function getQueries(): array

--- a/core/Model.php
+++ b/core/Model.php
@@ -10,13 +10,14 @@ abstract class Model
     public array $attributes = [];
     public array $rules = [];
     public array $labels = [];
-    protected array $rules_list = ['required', 'min', 'max', 'email'];
+    protected array $rules_list = ['required', 'min', 'max', 'email', 'unique'];
     protected array $errors = [];
     protected array $error_messages = [
         'required' => ':field-name: field is required',
         'email' => ':field-name: field must be a valid email address',
         'min' => ':field-name: field must be at least minimum :rule-value: characters',
-        'max' => ':field-name: field must be at most maximum :rule-value: characters'
+        'max' => ':field-name: field must be at most maximum :rule-value: characters',
+        'unique' => ':field-name: field must be unique',
     ];
 
     public function save(): false|string
@@ -156,6 +157,12 @@ abstract class Model
     protected function email($value, $rule_value): bool
     {
         return filter_var($value, FILTER_VALIDATE_EMAIL);
+    }
+
+    protected function unique($value, $rule_value): bool
+    {
+        $data = explode(',', $rule_value);
+        return !(db()->query("SELECT {$data[0]} FROM {$data[0]} WHERE {$data[1]} = :value", [':value' => $value])->getColumn());
     }
 
 }

--- a/core/Router.php
+++ b/core/Router.php
@@ -8,6 +8,7 @@ class Router
     public Response $response;
 
     protected array $routes = [];
+    public array $route_params = [];
 
     public function __construct(Request $request, Response $response)
     {
@@ -35,7 +36,7 @@ class Router
     {
         $path = $this->request->getPath();
         $method = $this->request->getMethod();
-        $callback = $this->routes[$method]["/{$path}"] ?? false;
+        $callback = $this->matchRoute($method, $path);
 
         if (false === $callback) {
             abort();
@@ -46,5 +47,21 @@ class Router
         }
 
         return call_user_func($callback);
+    }
+
+    private function matchRoute($method, $path)
+    {
+        foreach ($this->routes[$method] as $pattern => $route) {
+            if (preg_match("~^{$pattern}$~", "/{$path}", $matches)) {
+                foreach ($matches as $key => $value) {
+                    if (is_string($key)) {
+                        $this->route_params[$key] = $value;
+                    }
+                }
+                return $route;
+            }
+        }
+
+        return false;
     }
 }

--- a/helpers/helpers.php
+++ b/helpers/helpers.php
@@ -84,6 +84,11 @@ function session(): \MVCore\Session
     return app()->session;
 }
 
+function router(): \MVCore\Router
+{
+    return app()->router;
+}
+
 function get_alerts(): void
 {
     foreach (['success', 'error', 'info'] as $type) {

--- a/schema/test_data/mvcore_schema_posts.sql
+++ b/schema/test_data/mvcore_schema_posts.sql
@@ -1,5 +1,6 @@
 CREATE TABLE posts(
     id SERIAL PRIMARY KEY,
     title VARCHAR(255),
-    content TEXT
+    content TEXT,
+    slug VARCHAR(255) DEFAULT NULL UNIQUE
 );


### PR DESCRIPTION
### Description

- Updated `.gitignore` to refine log file exclusions.
- Created a slug input field for post creation.
- Added a `slug` column to the `posts` table and updated the `Post` model to include the `slug` field.
- Refactored `Database` methods and introduced new utility methods.
- Implemented a helper function for accessing the router instance.
- Updated home view links to use slugs for post URLs.
- Developed a new `show` method in `PostController` for displaying individual posts.
- Added a route to view posts via slugs and a corresponding view template.
- Refactored route matching to handle dynamic parameters effectively.
- Simplified the `HomeController` by removing unused session-related code.
- Enforced unique constraint on slugs using a new validation rule in the `Model` class.
- Added a placeholder for a temporary file catalog.